### PR TITLE
removed _io and change to import moduls it own line

### DIFF
--- a/splash.py
+++ b/splash.py
@@ -1,6 +1,9 @@
 #!/usr/bin/python3
 
-import warnings, os, sys, io, _io
+import warnings
+import os
+import sys
+import io
 
 i = input("splash 1.0 -#$ ")
 test = False


### PR DESCRIPTION
remove import _io as it is not used or needed in the code.

PEP 8 suggests import to be on separate lines.

so I change imports to be on separate lines 